### PR TITLE
javalin bump to 7.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 jetbrains-annotations = "org.jetbrains:annotations:26.1.0"
 jetty-webapp = { module = "org.eclipse.jetty.ee10:jetty-ee10-annotations", version.ref = "jetty" }
 jetty-websocket = { module = "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server", version.ref = "jetty" }
+jetty-websocket-jetty = { module = "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server", version.ref = "jetty" }
 # opens url in a browser
 vaadin-open = "com.vaadin:open:8.5.0.5"
 vaadin-core = { module = "com.vaadin:vaadin-core", version.ref = "vaadin" }
@@ -21,8 +22,7 @@ vaadin-bundle-prod = { module = "com.vaadin:vaadin-prod-bundle", version.ref = "
 # https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/
 junit = "org.junit.jupiter:junit-jupiter-engine:6.0.3"
 karibu-testing = "com.github.mvysny.kaributesting:karibu-testing-v24:2.7.0"
-# Javalin 6 doesn't support Jetty 12; upgrade to Javalin 7 once it's out.
-javalin = "io.javalin:javalin:5.6.5"
+javalin = "io.javalin:javalin:7.2.0"
 tomcat-core = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
 tomcat-jasper = { module = "org.apache.tomcat.embed:tomcat-embed-jasper", version.ref = "tomcat" }
 tomcat-websocket = { module = "org.apache.tomcat.embed:tomcat-embed-websocket", version.ref = "tomcat" }

--- a/testapp-kotlin-tomcat/build.gradle.kts
+++ b/testapp-kotlin-tomcat/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
     implementation(libs.javalin) {
         exclude(group = "org.eclipse.jetty")
+        exclude(group = "org.eclipse.jetty.ee10")
+        exclude(group = "org.eclipse.jetty.ee10.websocket")
         exclude(group = "org.eclipse.jetty.websocket")
         exclude(group = "com.fasterxml.jackson.core")
     }

--- a/testapp-kotlin-tomcat/src/main/kotlin/com/example/MyJavalinServlet.kt
+++ b/testapp-kotlin-tomcat/src/main/kotlin/com/example/MyJavalinServlet.kt
@@ -2,7 +2,7 @@ package com.example
 
 import io.javalin.Javalin
 import io.javalin.http.Context
-import io.javalin.http.servlet.JavalinServlet
+import jakarta.servlet.Servlet
 import jakarta.servlet.annotation.WebServlet
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
@@ -10,9 +10,9 @@ import jakarta.servlet.http.HttpServletResponse
 
 @WebServlet(name = "MyJavalinServlet", urlPatterns = ["/rest/*"])
 class MyJavalinServlet : HttpServlet() {
-    private val javalin: JavalinServlet = Javalin.createStandalone()
-        .get("/rest") { ctx: Context -> ctx.result("Hello!") }
-        .javalinServlet()
+    private val javalin: Servlet = Javalin.create { config ->
+        config.routes.get("/rest") { ctx: Context -> ctx.result("Hello!") }
+    }.javalinServlet()
 
     override fun service(req: HttpServletRequest, resp: HttpServletResponse) {
         javalin.service(req, resp)

--- a/testapp-kotlin/build.gradle.kts
+++ b/testapp-kotlin/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
     implementation(libs.javalin) {
         exclude(group = "org.eclipse.jetty")
+        exclude(group = "org.eclipse.jetty.ee10")
+        exclude(group = "org.eclipse.jetty.ee10.websocket")
         exclude(group = "org.eclipse.jetty.websocket")
         exclude(group = "com.fasterxml.jackson.core")
     }

--- a/testapp-kotlin/src/main/kotlin/com/example/MyJavalinServlet.kt
+++ b/testapp-kotlin/src/main/kotlin/com/example/MyJavalinServlet.kt
@@ -2,7 +2,7 @@ package com.example
 
 import io.javalin.Javalin
 import io.javalin.http.Context
-import io.javalin.http.servlet.JavalinServlet
+import jakarta.servlet.Servlet
 import jakarta.servlet.annotation.WebServlet
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
@@ -10,9 +10,9 @@ import jakarta.servlet.http.HttpServletResponse
 
 @WebServlet(name = "MyJavalinServlet", urlPatterns = ["/rest/*"])
 class MyJavalinServlet : HttpServlet() {
-    private val javalin: JavalinServlet = Javalin.createStandalone()
-        .get("/rest") { ctx: Context -> ctx.result("Hello!") }
-        .javalinServlet()
+    private val javalin: Servlet = Javalin.create { config ->
+        config.routes.get("/rest") { ctx: Context -> ctx.result("Hello!") }
+    }.javalinServlet()
 
     override fun service(req: HttpServletRequest, resp: HttpServletResponse) {
         javalin.service(req, resp)

--- a/vaadin-boot/build.gradle.kts
+++ b/vaadin-boot/build.gradle.kts
@@ -9,8 +9,12 @@ dependencies {
     // Embedded Jetty dependencies.
     // This one is needed to host webapps and perform classpath scanning for annotations
     api(libs.jetty.webapp)
-    // This one is required to have websocket/push support.
+    // This one is required to have websocket/push support (Jakarta flavor, used by Vaadin).
     implementation(libs.jetty.websocket)
+    // Jetty-flavor WebSocket API, so that embedded apps (e.g. Javalin) can register Jetty-style
+    // WebSockets. Also satisfies the SCI in jetty-ee10-websocket-jetty-server that scans for
+    // org.eclipse.jetty.websocket.api.WebSocketContainer at Jetty startup.
+    implementation(libs.jetty.websocket.jetty)
 
     testImplementation(libs.slf4j.simple)
     testImplementation(libs.junit)


### PR DESCRIPTION
## Summary
- Bump Javalin 5.6.5 → 7.2.0. Javalin 7 removed `createStandalone()` and moved routing into the upfront config block, so both Kotlin test servlets now use `Javalin.create { config -> config.routes.get(...) }.javalinServlet()`.
- Jetty 12 split its modules across new groupIds. Widened the Javalin exclusion list to also cover `org.eclipse.jetty.ee10` and `org.eclipse.jetty.ee10.websocket` — Javalin's own Jetty stays out; vaadin-boot's Jetty stays in.
- Added `jetty-ee10-websocket-jetty-server` to `vaadin-boot`. Gives vaadin-boot users Jetty-flavor WebSockets (alongside the existing Jakarta flavor) and satisfies the SCI that embedded libs like Javalin scan for at Jetty startup.

## Test plan
- [x] `./gradlew build` (unit tests pass for every module)
- [x] `cd test && ./system.rb` (system tests pass for all four testapps — Jetty + Tomcat × Java + Kotlin; `REST ok` on both kotlin variants confirms the new Javalin API works end-to-end)
- [ ] CI green on ubuntu-latest and macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)